### PR TITLE
Fix url otakudesu & `textsize` removal

### DIFF
--- a/API/otakudesu.py
+++ b/API/otakudesu.py
@@ -1,7 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 
-host = "https://otakudesu.pro/"
+host = "https://otakudesu.lol/"
 
 def getOngoing(next_page=1):
 	data = BeautifulSoup(requests.get(host + f"ongoing-anime/page/{next_page}/").text, features="html.parser")
@@ -81,7 +81,7 @@ def getDownload(url):
 
 
 def searchAnime(title):
-	a = BeautifulSoup(requests.get("https://otakudesu.pro/?s={}&post_type=anime".format(title)).content, features="html.parser")
+	a = BeautifulSoup(requests.get(host + "/?s={}&post_type=anime".format(title)).content, features="html.parser")
 	s = a.find("ul", {"class": "chivsrc"}).findAll("li")
 	data = []
 	for x in s:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -69,7 +69,7 @@ def write_eps_cover(img, eps):
 		fontData = stream.readAll()
 		stream.close()
 	font = ImageFont.truetype(BytesIO(fontData), 16)
-	text_w, text_h = draw.textsize(eps, font)
+	_, _, text_w, text_h = draw.textbbox((0,0), eps, font)
 	draw.rounded_rectangle((-30, h - h/12-2, text_w +12, h + text_h), 5, fill="#E8EFF5")
 	draw.text((5, h - text_h - 5), eps, "black", font=font)
 	return img


### PR DESCRIPTION
Changes:
* Changing otakudesu domain to `otakudesu.lol`
* PIL has removed `textsize` api, in exchange of method `textbbox` which return tuple of `left, top, text_w, text_h`

This pull changes will fix issue #1 