### PR TITLE
Add `lxml` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 bs4
+lxml
 PyQt5
 tqdm
 pillow


### PR DESCRIPTION
lxml depedencies is required when parsing bs4 with lxml features

```python 
BeautifulSoup(requests.get(f"{host}/embed-video/{Id}").content, features="lxml")
````